### PR TITLE
Llama demo for parallel api. Generate config.

### DIFF
--- a/llm/auto_parallel/llama/llama_with_api.sh
+++ b/llm/auto_parallel/llama/llama_with_api.sh
@@ -1,0 +1,101 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -x
+
+unset PADDLE_ELASTIC_JOB_ID
+unset PADDLE_TRAINER_ENDPOINTS
+unset DISTRIBUTED_TRAINER_ENDPOINTS
+unset FLAGS_START_PORT
+unset PADDLE_ELASTIC_TIMEOUT
+
+export NNODES=1
+export PADDLE_TRAINERS_NUM=1
+
+export GLOG_v=0
+
+export FLAGS_cudnn_deterministic=1
+export FLAGS_embedding_deterministic=1
+export FLAGS_max_inplace_grad_add=65536
+export FLAGS_enable_auto_parallel_align_mode=1
+export FLAGS_enable_pir_api=1
+
+task_name="llama_auto"
+rm -rf output
+rm -rf log
+
+export SOT_LOG_LEVEL=4
+export PYTHONPATH=../../../:$PYTHONPATH
+
+#ulimit -c unlimited
+
+python -u  -m paddle.distributed.launch \
+    --gpus "0,1,2,3,4,5,6,7" \
+    --log_dir  "log" \
+    ./run_pretrain_auto.py \
+    --model_name_or_path "facebook/llama-7b" \
+    --tokenizer_name_or_path "facebook/llama-7b" \
+    --input_dir "./data" \
+    --output_dir "./output" \
+    --split 949,50,1 \
+    --to_static false \
+    --pipeline_parallel_degree 2 \
+    --sharding_parallel_degree 2 \
+    --tensor_parallel_degree 2 \
+    --virtual_pp_degree 1 \
+    --pipeline_schedule_mode "VPP" \
+    --weight_decay 0.01 \
+    --warmup_ratio 0.01 \
+    --max_grad_norm 1.0 \
+    --learning_rate 3e-05 \
+    --min_learning_rate 3e-06 \
+    --max_steps 10 \
+    --logging_steps 1 \
+    --eval_steps 10000 \
+    --save_steps 1000 \
+    --continue_training 0 \
+    --do_train true \
+    --do_eval false \
+    --do_predict false \
+    --disable_tqdm true \
+    --save_total_limit 2 \
+    --device gpu \
+    --model_type "llama_network" \
+    --use_intermediate_api true \
+    --dataloader_num_workers 4 \
+    --distributed_dataloader 0 \
+    --enable_auto_parallel 1 \
+    --per_device_train_batch_size 1 \
+    --gradient_accumulation_steps 32 \
+    --per_device_eval_batch_size 1 \
+    --recompute false \
+    --recompute_use_reentrant true \
+    --skip_profile_timer true \
+    --recompute_granularity full \
+    --pp_recompute_interval 0 \
+    --bf16 true \
+    --fp16_opt_level "O2"  \
+    --amp_master_grad true \
+    --fuse_attention_ffn false \
+    --fuse_attention_qkv true \
+    --use_flash_attention true \
+    --use_fused_rope true \
+    --use_fused_rms_norm false \
+    --max_seq_length 4096 \
+    --sequence_parallel true \
+    --sharding "stage1" \
+    --sharding_parallel_config "enable_stage1_tensor_fusion enable_stage1_overlap" \
+    --tensor_parallel_config "enable_mp_async_allreduce" \
+    --num_hidden_layers 4 \
+    --auto_parallel_resume_form_hybrid_parallel true \

--- a/llm/auto_parallel/llama/run_pretrain_auto.py
+++ b/llm/auto_parallel/llama/run_pretrain_auto.py
@@ -579,10 +579,6 @@ def main():
         model = model_class.from_config(config, dtype="float32")
         criterion = criterion_class(config)
 
-    for param in model.parameters():
-        assert not param._is_initialized()
-        param.initialize()
-
     if training_args.recompute:
 
         def fn(layer):
@@ -636,6 +632,7 @@ def main():
         eval_dataset=eval_dataset if training_args.do_eval else None,
         optimizers=(None, lr_scheduler),
         tokenizer=tokenizer,
+        model_args=model_args,
     )
 
     checkpoint = None

--- a/paddlenlp/trainer/auto_trainer.py
+++ b/paddlenlp/trainer/auto_trainer.py
@@ -22,15 +22,14 @@ import paddle
 import paddle.distributed as dist
 import paddle.nn as nn
 from paddle.distributed import fleet
-from paddle.distributed.auto_parallel.intermediate.parallel_base import (
-    parallelize_model_and_optimizer,
-)
-from paddle.distributed.auto_parallel.intermediate.sharded_data_parallel import (
-    sharded_data_parallel,
+from paddle.distributed.auto_parallel.intermediate.parallelize import (
+    parallelize_model,
+    parallelize_optimizer,
 )
 from tqdm.auto import tqdm
 
 from paddlenlp.trainer import Trainer
+from paddlenlp.transformers.model_utils import PretrainedModel
 
 from ..utils.batch_sampler import DistributedBatchSampler as NlpDistributedBatchSampler
 from ..utils.log import logger
@@ -71,6 +70,44 @@ class AutoTrainer(Trainer):
                     return loss
 
                 kwargs.update({"criterion": loss_func})
+
+        if kwargs.get("args", None) is not None and kwargs["args"].use_intermediate_api:
+            model = kwargs.get("model", None)
+            assert model is not None
+            assert isinstance(model, PretrainedModel)
+            for param in model.parameters():
+                assert not param._is_initialized(), "intermediate_api needs lazy init"
+
+            sequence_parallel = False
+            if kwargs.get("model_args", None) is not None:
+                model_args = kwargs.pop("model_args")
+                if hasattr(model_args, "sequence_parallel"):
+                    sequence_parallel = model_args.sequence_parallel
+
+            auto_dist_degree = {
+                "tensor_parallel": kwargs["args"].tensor_parallel_degree > 1,
+                "sequence_parallel": sequence_parallel,
+                "pipeline_parallel": kwargs["args"].pipeline_parallel_degree > 1,
+                "data_sharding_parallel": kwargs["args"].dataset_world_size > 1,
+                "sharding": kwargs["args"].sharding,
+            }
+            auto_dist_config = model._generate_auto_dist_config(auto_dist_degree)
+            self.auto_dist_config = auto_dist_config
+
+            model = parallelize_model(
+                model,
+                dp_config=auto_dist_config["dp_config"],
+                mp_config=auto_dist_config["mp_config"],
+                pp_config=auto_dist_config["pp_config"],
+            )
+
+            kwargs["model"] = model
+
+        model = kwargs["model"]
+        for param in model.parameters():
+            if not param._is_initialized():
+                param.initialize()
+        kwargs["model"] = model
 
         super().__init__(*args, **kwargs)
         assert self.args.enable_auto_parallel
@@ -121,18 +158,17 @@ class AutoTrainer(Trainer):
         return dist_loader
 
     def _wrap_for_auto(self, model, train_dataloader):
-        logger.info(f"Wrapping model for auto paralle useing intermediate api {self.args.use_intermediate_api} ")
+        logger.info(f"Wrapping model for auto parallel using intermediate api {self.args.use_intermediate_api} ")
         dist_loader = self._wrap_for_dist_loader(train_dataloader)
         if self.args.use_intermediate_api:
-            level = None
-            if ShardingOption.SHARD_OP in self.args.sharding:
-                level = "os"
-            elif ShardingOption.SHARD_GRAD_OP in self.args.sharding:
-                level = "os_g"
-            elif ShardingOption.FULL_SHARD in self.args.sharding:
-                level = "p_g_os"
-            model, self.optimizer = sharded_data_parallel(model, self.optimizer, level)
-            model, self.optimizer = parallelize_model_and_optimizer(model, self.optimizer)
+            assert self.auto_dist_config is not None
+            self.optimizer = parallelize_optimizer(
+                model,
+                self.optimizer,
+                dp_config=self.auto_dist_config["dp_config"],
+                mp_config=self.auto_dist_config["mp_config"],
+                pp_config=self.auto_dist_config["pp_config"],
+            )
         else:
             if ShardingOption.SHARD_OP in self.args.sharding:
                 self.optimizer = dist.shard_optimizer(

--- a/paddlenlp/transformers/model_utils.py
+++ b/paddlenlp/transformers/model_utils.py
@@ -2631,6 +2631,100 @@ class PretrainedModel(Layer, GenerationMixin, ConversionMixin):
                 f"index located at {save_index_file}."
             )
 
+    def merge_auto_dist_configs(self, configs):
+        """
+        Merged all auto dist configs into one config.
+        """
+        assert isinstance(configs, (dict, list))
+        if isinstance(configs, dict):
+            return configs
+        final_config = {
+            "mp_config": None,
+            "sp_config": None,
+            "pp_config": None,
+        }
+        for config in configs:
+            if "mp_config" in config and config["mp_config"] is not None:
+                if final_config["mp_config"] is None:
+                    final_config["mp_config"] = config["mp_config"]
+                else:
+                    for k, v in config["mp_config"]["parallelize_plan"].items():
+                        assert k not in final_config["mp_config"]["parallelize_plan"].keys()
+                        final_config["mp_config"]["parallelize_plan"][k] = v
+            if "sp_config" in config and config["sp_config"] is not None:
+                if final_config["sp_config"] is None:
+                    final_config["sp_config"] = config["sp_config"]
+                else:
+                    for k, v in config["sp_config"]["parallelize_plan"].items():
+                        assert k not in final_config["sp_config"]["parallelize_plan"].keys()
+                        final_config["sp_config"]["parallelize_plan"][k] = v
+            if "pp_config" in config and config["pp_config"] is not None:
+                if isinstance(config["pp_config"]["split_spec"], str):
+                    config["pp_config"]["split_spec"] = [config["pp_config"]["split_spec"]]
+                    if final_config["pp_config"] is None:
+                        final_config["pp_config"] = config["pp_config"]
+                    else:
+                        final_config["pp_config"]["split_spec"] += config["pp_config"]["split_spec"]
+
+        if final_config["pp_config"] is not None and len(final_config["pp_config"]["split_spec"]) == 1:
+            final_config["pp_config"]["split_spec"] = final_config["pp_config"]["split_spec"][0]
+
+        return final_config
+
+    def _generate_auto_dist_config(self, auto_dist_degree):
+        merged_config = {
+            "sp_config": None,
+            "mp_config": None,
+            "pp_config": None,
+        }
+        for name, layer in self.named_sublayers(include_self=True):
+            if hasattr(layer, "auto_dist_config"):
+                if name != "":
+                    prefix = name + "."
+                else:
+                    prefix = ""
+                layer_config = layer.auto_dist_config(prefix)
+                merged_config = self.merge_auto_dist_configs([merged_config, layer_config])
+                for _, deeper_layer in layer.named_sublayers():
+                    if hasattr(deeper_layer, "auto_dist_config"):
+                        # mask all `auto_dist_config` methods in deeper layer
+                        deeper_layer.auto_dist_config = lambda x: {}
+
+        final_config = {
+            "dp_config": None,
+            "mp_config": None,
+            "pp_config": None,
+        }
+
+        if "tensor_parallel" in auto_dist_degree and auto_dist_degree["tensor_parallel"]:
+            merged_config["mp_config"] is not None
+            final_config["mp_config"] = merged_config["mp_config"]
+
+        if "sequence_parallel" in auto_dist_degree and auto_dist_degree["sequence_parallel"]:
+            merged_config["sp_config"] is not None
+            final_config["mp_config"] = merged_config["sp_config"]
+
+        if "pipeline_parallel" in auto_dist_degree and auto_dist_degree["pipeline_parallel"]:
+            merged_config["pp_config"] is not None
+            final_config["pp_config"] = merged_config["pp_config"]
+
+        if "data_sharding_parallel" in auto_dist_degree and auto_dist_degree["data_sharding_parallel"]:
+            # to avoid a circular import
+            from paddlenlp.trainer.trainer_utils import ShardingOption
+
+            level = 0
+            if "sharding" in auto_dist_degree and auto_dist_degree["sharding"] is not None:
+                sharding = auto_dist_degree["sharding"]
+                if ShardingOption.SHARD_OP in sharding:
+                    level = 1
+                if ShardingOption.SHARD_GRAD_OP in sharding:
+                    level = 2
+                if ShardingOption.FULL_SHARD in sharding:
+                    level = 3
+            final_config["dp_config"] = {"level": level}
+
+        return final_config
+
 
 class PipelinePretrainedModel(PretrainedModel):
     def __init_hook__(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaddleNLP/pull/26 -->
### PR types
New features

### PR changes
Models

### Description
一些思考与使用方式
1. 用户在使用中层api的时候，向AutoTrainer需要额外传递model_args参数。这是因为sequence_parallel的配置并不在training_args中体现，但是在生成config的时候需要区别tensor parallel与sequence parallel。所以当前需要额外传递model_args。但是感觉sequence parallel可以集成到training_args当中，这样就无需传递额外参数了。
2. 在PaddleNLP中PretrainedModel类提供两个新方法`_generate_auto_dist_config`与`merge_auto_dist_configs`。
- `def generate_auto_dist_config(self, auto_dist_degree)`，该方法由AutoTrainer直接调用
- `def merge_auto_dist_configs(self, configs)`，该方法帮助用户将很多模型的config进行merge操作。
3. PaddleNLP中的组网类中，需要实现auto_dist_config方法
- `def auto_dist_config(self, prefix="")`，该方法返回一个字典对象。其中，sp_config为sequence parallel的切分plan，mp_config为tensor parallel的切分plan，pp_config为pipeline parallel的切分plan。**无需提供dp_config**。
该方法会被PretrainedModel类中的`_generate_auto_dist_config`方法调用，生成最终的自动并行config。
```python
config = {
  "sp_config": {
      "parallelize_plan": {
          f"{prefix}xxx": xxx
      }
  },
  "mp_config": {
      "parallelize_plan": {
          f"{prefix}xxx": xxx
      }
  },
  "pp_config": {"split_spec":  f"{prefix}xxx"},
}
```
4. 当用户使用PaddleNLP中提供的基础模型进行组合使用的时候，用户可以不提供auto_dist_config方法，这样用户组网会使用基础模型中定义好的config进行分布式切分。如果用户想自定义config，用户也可以提供auto_dist_config方法。当然，用户完全可以不调用PaddleNLP中已经实现好的auto_dist_config方法，完全自主的进行config配置。
```python
class UserDefinedModel(PretrainedModel):
  def _init__(self):
    self.llama = LLama3DNet()
    self.vae = VAE3DNet()
    self.linear = nn.Linear()

  # 方案1：重新封装config
  def auto_dist_config(self, prefix=""):
    # get exist config
    llama_dist_config = self.llama.auto_dist_config(f'{prefix}llama.')
    vae_dist_config = self.vae.auto_dist_config(f'{prefix}vae')

    # update config
    llama_dist_config['mp_config']['parallelize_plan'].pop(f'{prefix}lm_head'.)
    llama_dist_config.pop('sp_config')
    vae_dist_config['pp_config'] = None

    # user defined
    config = {
        'mp_config': {
            f'{prefix}linear'}: RowWiseParallel()
        }
    }

    # merge configs into one
    return self.merge_auto_dist_configs([llama_dist_config, vae_dist_config, config])

  # 方案2：用户自定义config
  def auto_dist_config(self, prefix=""):
    config = {
        'mp_config': {
            f'{prefix}linear'}: RowWiseParallel()
        }
    }
    return config

  # 方案3：使用基础模型提供的config，完全不修改
```

#### 一些注意
* 当用户实现自己的auto_dist_config方法之后，所有更底层的auto_dist_config会失效。或者说，更高层的auto_dist_config方法的出现会屏蔽掉更底层的auto_dist_config方法。
* 组合模型需要有相同的分布式策略。用户可以通过修改auto_dist_config的方式来实现模型的部分组网的特殊且分配置（例如在上述例子中：
> 如果使用了pipeline parallel，那么vae部分的pipeline parallel被禁用了
> 如果使用了sequence parallel，那么llama部分的sequence parallel被禁用了。
> 如果使用了tensor parallel，那么llama部分的lm head不会被且分。
* 用户实现的模型必须继承自PretrainedModel，否则AutoTrainer中无法调用`_generate_auto_dist_config`方法。
* 必须使用lazy_init。
* prefix必须以`.`结尾。